### PR TITLE
Fixed bug in default config.

### DIFF
--- a/configs/server/config.js
+++ b/configs/server/config.js
@@ -474,7 +474,7 @@ module.exports =
 		webRtcTransport :
 		{
 			listenIps : getListenIps(),
-			/*[
+			/*listenIps : [
 				// change 192.0.2.1 IPv4 to your server's IPv4 address!!
 				//{ ip: '192.0.2.1', announcedIp: null }
 


### PR DESCRIPTION
Removing the block comment throws errors due to lack of listenIps key.