### PR TITLE
fix: revert amount of workers as env var

### DIFF
--- a/.env
+++ b/.env
@@ -16,7 +16,6 @@ BRANCH_MN_SERVER_SECRET=secret-shared-with-media-node
 LISTEN_PORT=3000
 RTC_MIN_PORT=40000
 RTC_MAX_PORT=40249
-MN_NUMBER_OF_WORKERS=1
 MN_DEBUG=edumeet*
 
 #edumeet-management-server

--- a/Dockerfile-media-node
+++ b/Dockerfile-media-node
@@ -14,9 +14,6 @@ ENV RTC_MIN_PORT=$rtcMinPort
 ARG rtcMaxPort=40249
 ENV RTC_MAX_PORT=$rtcMaxPort
 
-ARG numberOfWorkers=1
-ENV MN_NUMBER_OF_WORKERS=numberOfWorkers
-
 WORKDIR /app
 
 #install server build dependency
@@ -39,7 +36,7 @@ EXPOSE ${RTC_MIN_PORT}-${RTC_MAX_PORT}/udp
 EXPOSE ${RTC_MIN_PORT}-${RTC_MAX_PORT}/tcp
 
 ARG MN_DEBUG
-ENTRYPOINT DEBUG=${MN_DEBUG} yarn run prodstart --listenPort ${LISTEN_PORT} --rtcMinPort ${RTC_MIN_PORT} --rtcMaxPort ${RTC_MAX_PORT} --ip "0.0.0.0" --numberOfWorkers ${MN_NUMBER_OF_WORKERS} --secret ${BRANCH_MN_SERVER_SECRET} $0 $@
+ENTRYPOINT DEBUG=${MN_DEBUG} yarn run prodstart --listenPort ${LISTEN_PORT} --rtcMinPort ${RTC_MIN_PORT} --rtcMaxPort ${RTC_MAX_PORT} --ip "0.0.0.0" --secret ${BRANCH_MN_SERVER_SECRET} $0 $@
 
 
 

--- a/run-me-first.sh
+++ b/run-me-first.sh
@@ -37,14 +37,6 @@ done
 # Update TAG version
 # VERSION=$(curl -s "https://raw.githubusercontent.com/edumeet/${EDUMEET_SERVER}/${BRANCH_SERVER}/package.json" | grep version | sed -e 's/^.*:\ \"\(.*\)\",/\1/')
 
-#update number of workers
-# get cores
-#NUMBER_OF_WORKERS=$(grep ^cpu\\scores /proc/cpuinfo | uniq |  awk '{printf $4}')
-# get threads
-NUMBER_OF_WORKERS=$(grep siblings /proc/cpuinfo | uniq |  awk '{printf $3}')
-
-sed -i "s/^.*MN_NUMBER_OF_WORKERS.*$/MN_NUMBER_OF_WORKERS=${NUMBER_OF_WORKERS}/" .env
-
 
 echo -e "
 


### PR DESCRIPTION
I think we should revert the changes made related to `amountOfWorkers` arg passed to medianode.

The current default behavior on missing `amountOfWorkers` arg is good, we create as many mediasoup workers as max  threads.

If we want to change amountOfWorkers we can do:

# 1. using docker CLI
`docker run edumeet/edumeet-media-node:4.x-20230519-nightly --amountOfWorkers 3`

# 2 using docker-compose
 ```
services:
  media_node:
    container_name: "media_node"
    image: "edumeet/edumeet-media-node:4.x-20230519-nightly"
    command:
      - --amountOfWorkers
      - 3
```